### PR TITLE
This adds an additional safety check to the changes you had staged to the replication check

### DIFF
--- a/check_postgres.pl
+++ b/check_postgres.pl
@@ -1215,12 +1215,12 @@ Returns with an exit code of 0 (success), 1 (warning), 2 (critical), or 3 (unkno
 This is version $VERSION.
 
 Common connection options:
- -H,  --host=NAME         hostname(s) to connect to; defaults to none (Unix socket)
- -p,  --port=NUM          port(s) to connect to; defaults to $opt{defaultport}.
- -db, --dbname=NAME       database name(s) to connect to; defaults to 'postgres' or 'template1'
- -u   --dbuser=NAME       database user(s) to connect as; defaults to '$opt{defaultuser}'
-      --dbpass=PASS       database password(s); use a .pgpass file instead when possible
-      --dbservice=NAME    service name to use inside of pg_service.conf
+ -H,  --host=NAME       hostname(s) to connect to; defaults to none (Unix socket)
+ -p,  --port=NUM        port(s) to connect to; defaults to $opt{defaultport}.
+ -db, --dbname=NAME     database name(s) to connect to; defaults to 'postgres' or 'template1'
+ -u   --dbuser=NAME     database user(s) to connect as; defaults to '$opt{defaultuser}'
+      --dbpass=PASS     database password(s); use a .pgpass file instead when possible
+      --dbservice=NAME  service name to use inside of pg_service.conf
 
 Connection options can be grouped: --host=a,b --host=c --port=1234 --port=3344
 would connect to a-1234, b-1234, and c-3344


### PR DESCRIPTION
This re-enables your change to check the replay'd items `pg_last_xlog_receive_location() = pg_last_xlog_replay_location()` but adds a piece to it for additional security. As you denote, the slave could go out to lunch and we would still want it to report that it hasn't received anything to replay.

I added a variable with a default value of one hour that can be overridden. If the slave lags OR if the slave hasn't received any data in more time than the variable is configured for it will then alert critical.